### PR TITLE
The version number in "Setup with Maven" is not the latest stable.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1716,7 +1716,7 @@ boolean chosenSupport = ChosenListBox.isSupported();
 		&lt;dependency>
         	&lt;groupId>com.watopi&lt;/groupId>
             &lt;artifactId>gwtchosen&lt;/artifactId>
-            &lt;version>1.0.2&lt;/version>
+            &lt;version>1.1.0&lt;/version>
             &lt;scope>provided&lt;/scope>
         &lt;/dependency>
     &lt;/dependencies>


### PR DESCRIPTION
Unable to add a group (no addGroup method in ChosenListBox) in 1.0.2.
Using the version "1.1.0" instead of "1.0.2" fixed this issue for me.

http://jdramaix.github.com/gwtchosen/
