### PR TITLE
Performance improvements for long lists

### DIFF
--- a/plugin/src/main/java/com/watopi/chosen/client/ChosenImpl.java
+++ b/plugin/src/main/java/com/watopi/chosen/client/ChosenImpl.java
@@ -1352,14 +1352,16 @@ public class ChosenImpl {
                     }
 
                     if (found) {
-                        String text;
-                        if (searchText.length() > 0) {
-                            text = zregex.replace(optionContent, "<em>$1</em>");
-                        } else {
-                            text = optionContent;
+                        if (options.isHighlightSearchTerm()) {
+                            String text;
+                            if (searchText.length() > 0) {
+                                text = zregex.replace(optionContent, "<em>$1</em>");
+                            } else {
+                                text = optionContent;
+                            }
+                            result.html(text);
                         }
 
-                        result.html(text);
                         resultActivate(result);
 
                         if (option.getGroupArrayIndex() != -1) {

--- a/plugin/src/main/java/com/watopi/chosen/client/ChosenOptions.java
+++ b/plugin/src/main/java/com/watopi/chosen/client/ChosenOptions.java
@@ -32,6 +32,7 @@ public class ChosenOptions {
     private Resources resources;
     private boolean searchContains;
     private boolean singleBackstrokeDelete;
+    private boolean highlightSearchTerm;
 
     public ChosenOptions() {
         setDefault();
@@ -136,6 +137,15 @@ public class ChosenOptions {
         searchContains = false;
         singleBackstrokeDelete = false;
         maxSelectedOptions = -1;
+        highlightSearchTerm = true;
 
+    }
+
+    public boolean isHighlightSearchTerm() {
+        return highlightSearchTerm;
+    }
+
+    public void setHighlightSearchTerm(boolean highlightSearchTerm) {
+        this.highlightSearchTerm = highlightSearchTerm;
     }
 }

--- a/plugin/src/main/java/com/watopi/chosen/client/gwt/ChosenListBox.java
+++ b/plugin/src/main/java/com/watopi/chosen/client/gwt/ChosenListBox.java
@@ -534,6 +534,10 @@ public class  ChosenListBox extends ListBox implements HasAllChosenHandlers {
         options.setSingleBackstrokeDelete(singleBackstrokeDelete);
     }
 
+    public void setHighlightSearchTerm(boolean highlightSearchTerm) {
+        options.setHighlightSearchTerm(highlightSearchTerm);
+    }
+
     /**
      * Select all options with value present in <code>values</code> array and update the component.
      * @param values
@@ -609,5 +613,4 @@ public class  ChosenListBox extends ListBox implements HasAllChosenHandlers {
 
         return focusableElement;
     }
-
 }


### PR DESCRIPTION
All performance profiling was done against FireFox. Chrome is better performing in this case.

9f573f9 - On a long list (e.g. 5000 items) the calls to GQuery.children would add as much as 2 seconds to the time spent in ChosenListbox.onLoad
d12684d - Replacing call to GQuery.find.first with iteration improves performance
c4d8d9d - Result highlighting can be quite slow on long lists. Make it optional
