### PR TITLE
 Added new option to remove chosen component from tab index if disabled

### DIFF
--- a/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
@@ -320,6 +320,7 @@ public class ChosenImpl {
         resultClearHighlight();
         resultSingleSelected = null;
         resultsBuild();
+        setTabIndex();
     }
 
     private boolean activateField(Event e) {
@@ -1366,6 +1367,13 @@ public class ChosenImpl {
 
     private void setTabIndex() {
         String tabIndexProperty = $selectElement.attr(TABINDEX_PROPERTY);
+        if (options.isRemoveFromTabIndexWhenDisabled()) {
+            if (isDisabled) {
+                tabIndexProperty = "-1";
+            } else {
+                tabIndexProperty = "0";
+            }
+        }
         if (tabIndexProperty != null && tabIndexProperty.length() > 0) {
             $selectElement.attr(TABINDEX_PROPERTY, -1);
 

--- a/plugin/src/main/java/com/arcbees/chosen/client/ChosenOptions.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/ChosenOptions.java
@@ -31,6 +31,7 @@ public class ChosenOptions {
     private boolean singleBackstrokeDelete;
     private boolean highlightSearchTerm;
     private ResultsFilter resultFilter;
+    private boolean removeFromTabIndexWhenDisabled;
 
     public ChosenOptions() {
         setDefault();
@@ -163,6 +164,14 @@ public class ChosenOptions {
         singleBackstrokeDelete = false;
         maxSelectedOptions = -1;
         highlightSearchTerm = true;
+        removeFromTabIndexWhenDisabled = false;
+    }
 
+    public boolean isRemoveFromTabIndexWhenDisabled() {
+        return removeFromTabIndexWhenDisabled;
+    }
+
+    public void setRemoveFromTabIndexWhenDisabled(boolean removeFromTabIndexWhenDisabled) {
+        this.removeFromTabIndexWhenDisabled = removeFromTabIndexWhenDisabled;
     }
 }

--- a/plugin/src/main/java/com/arcbees/chosen/client/ChosenOptions.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/ChosenOptions.java
@@ -31,7 +31,6 @@ public class ChosenOptions {
     private boolean singleBackstrokeDelete;
     private boolean highlightSearchTerm;
     private ResultsFilter resultFilter;
-    private boolean removeFromTabIndexWhenDisabled;
 
     public ChosenOptions() {
         setDefault();
@@ -164,14 +163,5 @@ public class ChosenOptions {
         singleBackstrokeDelete = false;
         maxSelectedOptions = -1;
         highlightSearchTerm = true;
-        removeFromTabIndexWhenDisabled = false;
-    }
-
-    public boolean isRemoveFromTabIndexWhenDisabled() {
-        return removeFromTabIndexWhenDisabled;
-    }
-
-    public void setRemoveFromTabIndexWhenDisabled(boolean removeFromTabIndexWhenDisabled) {
-        this.removeFromTabIndexWhenDisabled = removeFromTabIndexWhenDisabled;
     }
 }

--- a/plugin/src/main/java/com/arcbees/chosen/client/event/UpdatedTabIndexEvent.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/event/UpdatedTabIndexEvent.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.arcbees.chosen.client.event;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class UpdatedTabIndexEvent extends GwtEvent<UpdatedTabIndexEvent.UpdatedTabIndexHandler> {
+    public interface UpdatedTabIndexHandler extends EventHandler {
+        void onUpdated(UpdatedTabIndexEvent event);
+    }
+
+    public static Type<UpdatedTabIndexHandler> TYPE = new Type<UpdatedTabIndexHandler>();
+
+    public static Type<UpdatedTabIndexHandler> getType() {
+        return TYPE;
+    }
+
+    public UpdatedTabIndexEvent() {
+    }
+
+    @Override
+    public Type<UpdatedTabIndexHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    @Override
+    protected void dispatch(UpdatedTabIndexHandler handler) {
+        handler.onUpdated(this);
+    }
+
+}

--- a/plugin/src/main/java/com/arcbees/chosen/client/gwt/ChosenListBox.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/gwt/ChosenListBox.java
@@ -15,31 +15,19 @@
  */
 package com.arcbees.chosen.client.gwt;
 
-import java.util.List;
-
 import com.arcbees.chosen.client.ChosenImpl;
 import com.arcbees.chosen.client.ChosenOptions;
-import com.arcbees.chosen.client.event.ChosenChangeEvent;
+import com.arcbees.chosen.client.event.*;
 import com.arcbees.chosen.client.event.ChosenChangeEvent.ChosenChangeHandler;
-import com.arcbees.chosen.client.event.HasAllChosenHandlers;
-import com.arcbees.chosen.client.event.HidingDropDownEvent;
 import com.arcbees.chosen.client.event.HidingDropDownEvent.HidingDropDownHandler;
-import com.arcbees.chosen.client.event.MaxSelectedEvent;
 import com.arcbees.chosen.client.event.MaxSelectedEvent.MaxSelectedHandler;
-import com.arcbees.chosen.client.event.ReadyEvent;
 import com.arcbees.chosen.client.event.ReadyEvent.ReadyHandler;
-import com.arcbees.chosen.client.event.ShowingDropDownEvent;
 import com.arcbees.chosen.client.event.ShowingDropDownEvent.ShowingDropDownHandler;
-import com.arcbees.chosen.client.event.UpdatedEvent;
 import com.arcbees.chosen.client.event.UpdatedEvent.UpdatedHandler;
 import com.arcbees.chosen.client.resources.Resources;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArrayString;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.NodeList;
-import com.google.gwt.dom.client.OptionElement;
-import com.google.gwt.dom.client.SelectElement;
+import com.google.gwt.dom.client.*;
 import com.google.gwt.event.dom.client.DomEvent.Type;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.LegacyHandlerWrapper;
@@ -51,6 +39,8 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.web.bindery.event.shared.EventBus;
 import com.google.web.bindery.event.shared.HandlerRegistration;
 import com.google.web.bindery.event.shared.SimpleEventBus;
+
+import java.util.List;
 
 import static com.arcbees.chosen.client.Chosen.CHOSEN_DATA_KEY;
 import static com.arcbees.chosen.client.Chosen.Chosen;
@@ -338,7 +328,7 @@ public class  ChosenListBox extends ListBox implements HasAllChosenHandlers {
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);
 
-        update();
+        updateTabIndex();
     }
 
     public void forceRedraw() {
@@ -752,4 +742,13 @@ public class  ChosenListBox extends ListBox implements HasAllChosenHandlers {
         return focusableElement;
     }
 
+    @Override
+    public void setTabIndex(int index) {
+        super.setTabIndex(index);
+        updateTabIndex();
+    }
+
+    private void updateTabIndex() {
+        ensureChosenHandlers().fireEvent(new UpdatedTabIndexEvent());
+    }
 }


### PR DESCRIPTION
This is possible solution for #137. If the new option ```removeFromTabIndexWhenDisabled``` is active and the component is disabled than the tab index is set to ```-1``` in order to remove the component from the tab index. Once the component will be enabled again the tab index is set to ```0````