### PR TITLE
Fix issue #105

### DIFF
--- a/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
@@ -1521,7 +1521,7 @@ public class ChosenImpl {
         } else {
             closeField();
         }
-        return false;
+        return true;
     }
 
     private void winnowResults(boolean isShowing) {


### PR DESCRIPTION
When Chosen has the focus, the click on other ui element doesn't work because chosen catch the click event on the body and stop the propagation.
