### PR TITLE
Select with options with label attribute doesn't work with chosen

### DIFF
--- a/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
@@ -136,6 +136,9 @@ public class ChosenImpl {
                         String resultId = option.getDomId();
                         GQuery result = $("#" + resultId);
                         String optionContent = option.getHtml();
+                        if (optionContent == null || optionContent.trim().isEmpty()) {
+                            optionContent = option.getText();
+                        }
 
                         if (regex.test(optionContent)) {
                             found = true;

--- a/plugin/src/main/java/com/arcbees/chosen/client/SelectParser.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/SelectParser.java
@@ -259,7 +259,12 @@ public class SelectParser {
             }
 
             item.value = option.getValue();
-            item.text = option.getText();
+
+            item.text = option.getLabel();
+            if (isNullOrEmpty(item.text)) {
+                item.text = option.getText();
+            }
+
             item.html = option.getInnerHTML();
             item.selected = option.isSelected();
             item.disabled = groupDisabled ? groupDisabled : option.isDisabled();
@@ -276,6 +281,10 @@ public class SelectParser {
 
         parsed.add(item);
         optionsIndex++;
+    }
+
+    private boolean isNullOrEmpty(String s) {
+        return s == null || s.isEmpty();
     }
 
     private native String getCssText(Style s)/*-{


### PR DESCRIPTION
Follow W3C standard to get the text of an option.

According to http://www.w3.org/TR/html5/forms.html#the-option-element and http://www.w3.org/TR/html401/interact/forms.html#edef-OPTION

> When rendering a menu choice, user agents should use the value of the label attribute of the OPTION element as the choice. If this attribute is not specified, user agents should use the contents of the OPTION element.
