### PR TITLE
Don't clear search input on update

### DIFF
--- a/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
@@ -326,7 +326,7 @@ public class ChosenImpl {
         setDefaultText();
         resultClearHighlight();
         resultSingleSelected = null;
-        resultsBuild();
+        resultsBuild(false);
     }
 
     private boolean activateField(Event e) {
@@ -1043,7 +1043,7 @@ public class ChosenImpl {
         }
     }
 
-    private void resultsBuild() {
+    private void resultsBuild(boolean init) {
         selectItems = new SelectParser().parse(selectElement);
 
         if (isMultiple && choices > 0) {
@@ -1059,7 +1059,7 @@ public class ChosenImpl {
             }
         }
 
-        rebuildResultItems(true);
+        rebuildResultItems(init);
     }
 
     public void rebuildResultItems() {
@@ -1504,7 +1504,7 @@ public class ChosenImpl {
             searchField.css("width", searchFieldWidth + "px");
         }
 
-        resultsBuild();
+        resultsBuild(true);
 
         setTabIndex();
 


### PR DESCRIPTION
With an async filter and ChosenValueListBox, we need to call setAcceptableValues. From there, setSelectedItem() is called and later update() is. We end up with the search field being cleared as we type.
