### PR TITLE
Allow null values to be treated as deselect options.

### DIFF
--- a/integration-test/src/main/java/com/arcbees/chosen/integrationtest/client/ChosenSampleIntegrationTests.java
+++ b/integration-test/src/main/java/com/arcbees/chosen/integrationtest/client/ChosenSampleIntegrationTests.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.arcbees.chosen.integrationtest.client.testcases.AllowSingleDeselect;
+import com.arcbees.chosen.integrationtest.client.testcases.AllowSingleDeselectNullNonEmpty;
 import com.arcbees.chosen.integrationtest.client.testcases.ChooseOption;
 import com.arcbees.chosen.integrationtest.client.testcases.DisableSearchThreshold;
 import com.arcbees.chosen.integrationtest.client.testcases.EnabledDisabled;
@@ -52,6 +53,7 @@ public class ChosenSampleIntegrationTests implements EntryPoint, ValueChangeHand
         registerTestCase(new HideEmptyValues());
         registerTestCase(new ShowNonEmptyValues());
         registerTestCase(new AllowSingleDeselect());
+        registerTestCase(new AllowSingleDeselectNullNonEmpty());
         registerTestCase(new TabNavigation());
         registerTestCase(new EnabledDisabled());
         registerTestCase(new Above());

--- a/integration-test/src/main/java/com/arcbees/chosen/integrationtest/client/testcases/AllowSingleDeselectNullNonEmpty.java
+++ b/integration-test/src/main/java/com/arcbees/chosen/integrationtest/client/testcases/AllowSingleDeselectNullNonEmpty.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.arcbees.chosen.integrationtest.client.testcases;
+
+import com.arcbees.chosen.integrationtest.client.domain.CarBrand;
+import com.arcbees.chosen.integrationtest.client.domain.DefaultCarRenderer;
+import com.google.gwt.text.shared.Renderer;
+
+public class AllowSingleDeselectNullNonEmpty extends AllowSingleDeselect {
+    private static final String SELECT_ONE = "Select One";
+
+    @Override
+    protected Renderer<CarBrand> getRenderer() {
+        return new DefaultCarRenderer() {
+            @Override
+            public String render(CarBrand carBrand) {
+                if (carBrand == null) {
+                    return SELECT_ONE;
+                }
+                return super.render(carBrand);
+            }
+        };
+    }
+}

--- a/integration-test/src/test/java/ChosenIT.java
+++ b/integration-test/src/test/java/ChosenIT.java
@@ -141,7 +141,7 @@ public class ChosenIT {
     }
 
     /**
-     * Goal: ensure allowSingleDeselect shows the X/cross when there is a value
+     * Goal: ensure allowSingleDeselect shows the X/cross when there is a value.
      */
     @Test
     public void allowSingleDeselect_visibleOnSelection() {

--- a/integration-test/src/test/java/ChosenIT.java
+++ b/integration-test/src/test/java/ChosenIT.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import com.arcbees.chosen.integrationtest.client.TestCase;
 import com.arcbees.chosen.integrationtest.client.domain.CarBrand;
 import com.arcbees.chosen.integrationtest.client.testcases.AllowSingleDeselect;
+import com.arcbees.chosen.integrationtest.client.testcases.AllowSingleDeselectNullNonEmpty;
 import com.arcbees.chosen.integrationtest.client.testcases.ChooseOption;
 import com.arcbees.chosen.integrationtest.client.testcases.DisableSearchThreshold;
 import com.arcbees.chosen.integrationtest.client.testcases.EnabledDisabled;
@@ -128,6 +129,22 @@ public class ChosenIT {
     public void allowSingleDeselect() {
         // Given
         loadTestCase(new AllowSingleDeselect());
+        clickOption(CADILLAC, RENDERER);
+
+        // When
+        singleDeselect();
+
+        // Then
+        assertThat(getSelectedOptionText()).isEqualTo(AllowSingleDeselect.PLACEHOLDER);
+    }
+
+    /**
+     * Goal: ensure allowSingleDeselect is working properly when a null renderer isn't an empty string.
+     */
+    @Test
+    public void allowSingleDeselect_nullNonEmpty() {
+        // Given
+        loadTestCase(new AllowSingleDeselectNullNonEmpty());
         clickOption(CADILLAC, RENDERER);
 
         // When

--- a/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
@@ -406,6 +406,7 @@ public class ChosenImpl {
         if (eventBus != null) {
             updateEventHandlerRegistration =
                     eventBus.addHandler(UpdatedEvent.getType(), new UpdatedEvent.UpdatedHandler() {
+                        @Override
                         public void onUpdated(UpdatedEvent event) {
                             update();
                         }
@@ -514,6 +515,7 @@ public class ChosenImpl {
         searchContainer.before(ChozenTemplate.templates.choice(choiceId, css.searchChoice(), html,
                 css.searchChoiceClose(), "" + option.getArrayIndex(), option.getValue(), css.iconCross()).asString());
         $('#' + choiceId).find("a").click(new Function() {
+            @Override
             public boolean f(final Event e) {
                 choiceDestroyLinkClick(e);
                 return false;
@@ -663,6 +665,7 @@ public class ChosenImpl {
         if (!mouseOnContainer) {
             activeField = false;
             Scheduler.get().scheduleFixedDelay(new RepeatingCommand() {
+                @Override
                 public boolean execute() {
                     blurTest();
                     return false;
@@ -675,6 +678,7 @@ public class ChosenImpl {
     private boolean inputFocus(final Event e) {
         if (!activeField) {
             Scheduler.get().scheduleFixedDelay(new RepeatingCommand() {
+                @Override
                 public boolean execute() {
                     containerMouseDown(e);
                     return false;
@@ -1445,7 +1449,7 @@ public class ChosenImpl {
         NodeList<OptionElement> optionsList = selectElement.getOptions();
         allowSingleDeselect =
                 options.isAllowSingleDeselect() && optionsList.getLength() > 0
-                        && "".equals(optionsList.getItem(0).getText());
+                        && "".equals(optionsList.getItem(0).getValue());
 
         choices = 0;
 

--- a/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
@@ -1108,14 +1108,15 @@ public class ChosenImpl {
                         choiceBuild(optionItem);
                     } else {
                         selectedItem.removeClass(css.chznDefault()).find("span").text(optionItem.getText());
-                        if (allowSingleDeselect) {
-                            singleDeselectControlBuild();
-                        }
 
                         selectedValues.clear();
                     }
 
                     selectedValues.add(optionItem.getValue());
+
+                    if (!isMultiple && allowSingleDeselect) {
+                        singleDeselectControlBuild();
+                    }
                 }
             }
         }

--- a/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/ChosenImpl.java
@@ -1027,9 +1027,6 @@ public class ChosenImpl {
                 choiceBuild(item);
             } else {
                 selectedItem.find("span").text(item.getText());
-                if (allowSingleDeselect) {
-                    singleDeselectControlBuild();
-                }
             }
 
             if (!e.getMetaKey() || !isMultiple) {
@@ -1046,6 +1043,10 @@ public class ChosenImpl {
             }
 
             selectedValues.add(newValue);
+
+            if (!isMultiple && allowSingleDeselect) {
+                singleDeselectControlBuild();
+            }
 
             if (isMultiple || oldValue == null || !oldValue.equals($selectElement.val())) {
                 fireEvent(new ChosenChangeEvent(newValue, position, this));
@@ -1580,7 +1581,8 @@ public class ChosenImpl {
     }
 
     private void singleDeselectControlBuild() {
-        if (allowSingleDeselect && selectedItem.find("abbr").isEmpty()) {
+        if (allowSingleDeselect && selectedItem.find("abbr").isEmpty()
+                && getCurrentValue() != null && !"".equals(getCurrentValue())) {
             selectedItem.find("span").first().after(
                     "<abbr class=\"" + css.searchChoiceClose() + " " + css.iconCross() + "\"></abbr>");
         }

--- a/plugin/src/main/java/com/arcbees/chosen/client/gwt/ChosenValueListBox.java
+++ b/plugin/src/main/java/com/arcbees/chosen/client/gwt/ChosenValueListBox.java
@@ -152,7 +152,12 @@ public class ChosenValueListBox<T> extends BaseChosenValueListBox<T> implements 
 
     @Override
     protected void addItemToChosenListBox(T value) {
-        getChosenListBox().addItem(renderer.render(value));
+        if (value == null) {
+            // Treat null value as empty so that ChosenImpl can do a allowSingleDeselect
+            getChosenListBox().addItem(renderer.render(value), "");
+        } else {
+            getChosenListBox().addItem(renderer.render(value));
+        }
     }
 
     private void setValue(T newValue, boolean fireEvents, boolean update) {


### PR DESCRIPTION
When a renderer doesn't render null as an empty string "" the setting allowSingleDeselect doesn't take effect.  Therefore, when ChosenValueListBox encounters a null value it passes an empty string as
the list box item's value.  ChosenImpl now looks at the <option> element's value attribute to detect this, while keeping the old functionality operational.